### PR TITLE
Fixed issue on v3.1

### DIFF
--- a/addons/sketchfab/Api.gd
+++ b/addons/sketchfab/Api.gd
@@ -147,7 +147,7 @@ func _handle_result(result):
 	# HTTP error
 	var kind = result.code / 100
 	if kind == 4:
-		return NOT_AUTHORIZED
+		return SymbolicErrors.NOT_AUTHORIZED
 	elif kind == 5:
 		OS.alert('Server error. Try again later.', 'Error')
 		return null


### PR DESCRIPTION
Fixes the error  on Godot 3.1
`res://addons/sketchfab/Api.gd:150 - Parse Error: Identifier 'NOT_AUTHORIZED' is not declared in the current scope.`
