### PR TITLE
Updates Client ID

### DIFF
--- a/addons/sketchfab/Api.gd
+++ b/addons/sketchfab/Api.gd
@@ -5,7 +5,7 @@ const OAUTH_HOSTNAME = "sketchfab.com"
 const API_HOSTNAME = "api.sketchfab.com"
 const USE_SSL = true
 const BASE_PATH = "/v3"
-const CLIENT_ID = "IUO8d5VVOIUCzWQArQ3VuXfbwx5QekZfLeDlpOmW"
+const CLIENT_ID = "a99JEwOhmIWHdRRDDgBsxbBf8ufC0ACoUcDAifSV"
 
 enum SymbolicErrors {
 	NOT_AUTHORIZED,


### PR DESCRIPTION
We had been using the same Client ID as our Unity plugin, making it impossible to track usage correctly. I've generated new OAuth app credentials for this plugin.